### PR TITLE
Support esp-idf master, add .travis.yml, import an example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
       - PROJECT_TARGET="esp32"
       - PROJECT_SDK_BRANCH="v3.2.2"
       - PROJECT_BUILD_METHOD="make"
+    - env:
+      - PROJECT_TARGET="esp32"
+      - PROJECT_SDK_BRANCH="v3.2.0"
+      - PROJECT_BUILD_METHOD="make"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,176 @@
+sudo: false
+language: bash
+
+# when you suspects issues in cache, use the following line to disable cache.
+# cache: false
+cache:
+  directories:
+    - ${HOME}/distfiles
+    - ${HOME}/.ccache
+    - ${HOME}/.cache/pip
+os:
+  - linux
+
+matrix:
+  include:
+    # in version esp-idf 4.x, both idf.py and make are officially supported
+    # build method by espressif.
+    #
+    # in version 3.x, make is the supported build method.
+    #
+    # in the latest ESP8266 RTOS SDK (3.2), idf.py is included but not
+    # officially supported by espressif.
+    - env:
+      - PROJECT_TARGET="esp32"
+      - PROJECT_SDK_BRANCH="master"
+      - PROJECT_BUILD_METHOD="make"
+    - env:
+      - PROJECT_TARGET="esp32"
+      - PROJECT_SDK_BRANCH="master"
+      - PROJECT_BUILD_METHOD="idf"
+    - env:
+      - PROJECT_TARGET="esp32"
+      - PROJECT_SDK_BRANCH="v3.2.2"
+      - PROJECT_BUILD_METHOD="make"
+
+addons:
+  apt:
+    packages:
+      - gcc
+      - wget
+      - make
+      - libncurses-dev
+      - flex
+      - bison
+      - python
+      - python-pip
+      - gperf
+      - ccache
+
+before_install:
+  # Save path to the git respository
+  - PROJECT_PATH=$(pwd)
+
+install:
+  - export TOOLCHAIN_DIR="${HOME}/${PROJECT_TARGET}"
+  # PROJECT_TOOLCHAIN_FILE, and its URLs, can be found at `tools/tools.json`
+  # in `esp-idf`.
+  - |
+    case ${PROJECT_TARGET} in
+    esp8266)
+      export PROJECT_GCC_PREFIX="xtensa-lx106-elf"
+      export PROJECT_TOOLCHAIN_FILE="xtensa-lx106-elf-linux64-1.22.0-92-g8facf4c-5.2.0.tar.gz"
+      export PROJECT_SDK_NAME="ESP8266_RTOS_SDK"
+      ;;
+    esp32)
+      export PROJECT_GCC_PREFIX="xtensa-esp32-elf"
+      export PROJECT_SDK_NAME="esp-idf"
+      case ${PROJECT_SDK_BRANCH} in
+      v3.*)
+        export PROJECT_TOOLCHAIN_FILE="xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz"
+        ;;
+      master)
+        export PROJECT_TOOLCHAIN_FILE="xtensa-esp32-elf-gcc8_2_0-esp-2019r2-linux-amd64.tar.gz"
+        ;;
+      *)
+        echo "Unknown PROJECT_SDK_BRANCH: ${PROJECT_SDK_BRANCH}"
+        exit 1
+        ;;
+      esac
+      ;;
+    *)
+      echo "Unknown PROJECT_TARGET: ${PROJECT_TARGET}"
+      exit 1
+      ;;
+    esac
+  - export PROJECT_GCC_FILE="${PROJECT_GCC_PREFIX}-gcc"
+  - export PROJECT_DISTFILE_DIR="${HOME}/distfiles"
+  - export IDF_PATH=${TOOLCHAIN_DIR}/${PROJECT_SDK_NAME}
+  - export PROJECT_LOG="${HOME}/build.log"
+  - export PROJECT_EXAMPLE_DIR="${PROJECT_PATH}/examples"
+  - |
+    case ${PROJECT_BUILD_METHOD} in
+    idf)
+      export PROJECT_BUILD_COMMAND="python ${IDF_PATH}/tools/idf.py"
+      export PROJECT_BUILD_COMMAND_ARG="build"
+      ;;
+    make)
+      export PROJECT_BUILD_COMMAND="make"
+      export PROJECT_BUILD_COMMAND_ARG="-j2"
+      ;;
+    *)
+      echo "Unknown PROJECT_BUILD_METHOD: ${PROJECT_BUILD_METHOD}"
+      exit 1
+      ;;
+    esac
+  - echo ${PROJECT_CONFIG_IDF_TARGET_ESP32}
+  # Install ESP32 toochain following steps as desribed
+  # in http://esp-idf.readthedocs.io/en/latest/linux-setup.html
+
+  # Prepare directory for the toolchain
+  - mkdir -p ${TOOLCHAIN_DIR} ${PROJECT_DISTFILE_DIR}
+  # Get SDK from github
+  - git clone --branch ${PROJECT_SDK_BRANCH} --recursive https://github.com/espressif/${PROJECT_SDK_NAME}.git ${IDF_PATH}
+
+  # Setup ccache to build faster
+  # XXX when the entire build process exceeds 50 min, th job will be killed
+  # https://docs.travis-ci.com/user/customizing-the-build/#build-timeouts
+  - ccache --version
+  - mkdir ${HOME}/ccache_bin
+  - (cd ${HOME}/ccache_bin && ln -s /usr/bin/ccache ${PROJECT_GCC_FILE})
+  - export CCACHE_BASEDIR=$PROJECT_PATH
+  - export CCACHE_CPP2=true
+
+  # Get Python requirements
+  - python -m pip install --user --upgrade pyOpenSSL
+  - python -m pip install --user -r ${IDF_PATH}/requirements.txt
+
+  # Download binary toolchain if it does not exist
+  - |
+    if [ ! -f ${PROJECT_DISTFILE_DIR}/${PROJECT_TOOLCHAIN_FILE} ]; then
+      wget -O ${PROJECT_DISTFILE_DIR}/${PROJECT_TOOLCHAIN_FILE} https://dl.espressif.com/dl/${PROJECT_TOOLCHAIN_FILE}
+    fi
+  - tar -xz -C ${TOOLCHAIN_DIR} -f ${PROJECT_DISTFILE_DIR}/${PROJECT_TOOLCHAIN_FILE}
+
+  # Make toolchains available for all terminal sessions
+  - export PATH=$HOME/ccache_bin:$PATH:$HOME/${PROJECT_TARGET}/${PROJECT_GCC_PREFIX}/bin
+
+script:
+  - rm -f ${PROJECT_LOG}
+
+  # show what is actually executed because travis does not show expanded
+  # variables in logs.
+  - echo "build command ${PROJECT_BUILD_COMMAND} ${PROJECT_BUILD_COMMAND_ARG}"
+
+  # XXX surpress log output where possible. when the size exceeds 4 MB, the
+  # job will be killed.
+  - |
+    IGNORE_FILE="travis-ignore"
+
+    case ${PROJECT_TARGET} in
+      esp32)
+        ;;
+      esp8266)
+        IGNORE_FILE="travis-ignore-esp8266"
+        ;;
+    esac
+
+    cd ${PROJECT_EXAMPLE_DIR}
+    for i in $(ls -d */); do
+      if [ ! -e ${PROJECT_EXAMPLE_DIR}/${i}/${IGNORE_FILE} ]; then
+        echo "Building ${i}..."
+        cd ${PROJECT_EXAMPLE_DIR}/${i}
+        # idf.py does not have defconfig
+        make defconfig || exit 1
+        ${PROJECT_BUILD_COMMAND} ${PROJECT_BUILD_COMMAND_ARG} >> ${PROJECT_LOG}
+        if [ $? -ne 0 ]; then
+          # when failed, show last 100 lines for debugging, and exit with
+          # non-zero exit code
+          tail -n 100 ${PROJECT_LOG}
+          exit 1
+        fi
+        make clean >/dev/null
+        # make sure the directory is clean
+        rm -rf ${i}/sdkconfig ${i}/build
+      fi
+    done

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       - PROJECT_BUILD_METHOD="make"
     - env:
       - PROJECT_TARGET="esp32"
-      - PROJECT_SDK_BRANCH="v3.2.0"
+      - PROJECT_SDK_BRANCH="v3.2"
       - PROJECT_BUILD_METHOD="make"
 
 addons:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(SRCS "homie.c" "ota.c"
+    REQUIRES "app_update" "mqtt" "esp_https_ota"
+    INCLUDE_DIRS "include" "."
+)

--- a/examples/esp32-homie-example/.gitignore
+++ b/examples/esp32-homie-example/.gitignore
@@ -1,0 +1,3 @@
+/build
+/sdkconfig
+/sdkconfig.old

--- a/examples/esp32-homie-example/.gitmodules
+++ b/examples/esp32-homie-example/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "components/esp32-homie"]
+	path = components/esp32-homie
+	url = https://github.com/craftmetrics/esp32-homie.git
+[submodule "components/esp32mqtt"]
+	path = components/esp32mqtt
+	url = https://github.com/tuanpmt/espmqtt
+[submodule "components/esp-request"]
+	path = components/esp-request
+	url = https://github.com/tuanpmt/esp-request

--- a/examples/esp32-homie-example/.gitmodules
+++ b/examples/esp32-homie-example/.gitmodules
@@ -1,9 +1,0 @@
-[submodule "components/esp32-homie"]
-	path = components/esp32-homie
-	url = https://github.com/craftmetrics/esp32-homie.git
-[submodule "components/esp32mqtt"]
-	path = components/esp32mqtt
-	url = https://github.com/tuanpmt/espmqtt
-[submodule "components/esp-request"]
-	path = components/esp-request
-	url = https://github.com/tuanpmt/esp-request

--- a/examples/esp32-homie-example/CMakeLists.txt
+++ b/examples/esp32-homie-example/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The following four lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(MAIN_SRCS main/main.c)
+set(EXTRA_COMPONENT_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(esp32-homie-example)

--- a/examples/esp32-homie-example/CMakeLists.txt
+++ b/examples/esp32-homie-example/CMakeLists.txt
@@ -1,0 +1,6 @@
+# The following four lines of boilerplate have to be in your project's CMakeLists
+# in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+set(MAIN_SRCS main/main.c)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(esp32-homie-example)

--- a/examples/esp32-homie-example/LICENSE
+++ b/examples/esp32-homie-example/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Craft Metrics Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/esp32-homie-example/Makefile
+++ b/examples/esp32-homie-example/Makefile
@@ -1,0 +1,8 @@
+#
+# This is a project Makefile. It is assumed the directory this Makefile resides in is a
+# project subdirectory.
+#
+
+PROJECT_NAME := esp32-homie-example
+
+include $(IDF_PATH)/make/project.mk

--- a/examples/esp32-homie-example/Makefile
+++ b/examples/esp32-homie-example/Makefile
@@ -5,4 +5,6 @@
 
 PROJECT_NAME := esp32-homie-example
 
+EXTRA_COMPONENT_DIRS := $(CURDIR)/../../
+
 include $(IDF_PATH)/make/project.mk

--- a/examples/esp32-homie-example/README.md
+++ b/examples/esp32-homie-example/README.md
@@ -1,0 +1,9 @@
+# esp32-homie-example
+
+An example project for https://github.com/craftmetrics/esp32-homie
+
+## How to use
+
+ 1. Install and set up the [ESP-IDF toolchain](http://esp-idf.readthedocs.io)
+ 1. `make menuconfig` and fill out the "ESP32 Homie Example" and serial flasher section
+ 1. `make -j4 flash monitor`

--- a/examples/esp32-homie-example/main/CMakeLists.txt
+++ b/examples/esp32-homie-example/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "main.c"
+                    INCLUDE_DIRS ".")

--- a/examples/esp32-homie-example/main/Kconfig.projbuild
+++ b/examples/esp32-homie-example/main/Kconfig.projbuild
@@ -2,26 +2,31 @@ menu "ESP32 Homie Example"
 
 config WIFI_SSID
     string "WiFi SSID"
+    default "myssid"
     help
         SSID (network name) to connect to.
 
 config WIFI_PASSWORD
     string "WiFi Password"
+    default "mypassword"
     help
         WiFi password (WPA or WPA2).
 
 config MQTT_URI
     string "MQTT Broker URI"
+    default "mqtt://test.example.org:1883"
     help
         URI to the MQTT broker.
 
 config MQTT_USERNAME
     string "MQTT Username"
+    default "user"
     help
         Username for connecting to the MQTT broker.
 
 config MQTT_PASSWORD
     string "MQTT Password"
+    default "password"
     help
         Password for connecting to the MQTT broker.
 

--- a/examples/esp32-homie-example/main/Kconfig.projbuild
+++ b/examples/esp32-homie-example/main/Kconfig.projbuild
@@ -1,0 +1,28 @@
+menu "ESP32 Homie Example"
+
+config WIFI_SSID
+    string "WiFi SSID"
+    help
+        SSID (network name) to connect to.
+
+config WIFI_PASSWORD
+    string "WiFi Password"
+    help
+        WiFi password (WPA or WPA2).
+
+config MQTT_URI
+    string "MQTT Broker URI"
+    help
+        URI to the MQTT broker.
+
+config MQTT_USERNAME
+    string "MQTT Username"
+    help
+        Username for connecting to the MQTT broker.
+
+config MQTT_PASSWORD
+    string "MQTT Password"
+    help
+        Password for connecting to the MQTT broker.
+
+endmenu

--- a/examples/esp32-homie-example/main/component.mk
+++ b/examples/esp32-homie-example/main/component.mk
@@ -1,0 +1,4 @@
+#
+# "main" pseudo-component makefile.
+#
+# (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)

--- a/examples/esp32-homie-example/main/main.c
+++ b/examples/esp32-homie-example/main/main.c
@@ -2,14 +2,14 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdio.h>
-#include "nvs_flash.h"
+#include <freertos/FreeRTOS.h>
+#include <freertos/event_groups.h>
+#include <nvs_flash.h>
+#include <esp_system.h>
+#include <esp_wifi.h>
+#include <esp_event_loop.h>
+#include <esp_log.h>
 
-#include "esp_system.h"
-#include "esp_wifi.h"
-#include "esp_event_loop.h"
-#include "freertos/event_groups.h"
-
-#include "esp_log.h"
 #include "homie.h"
 
 static const char* TAG = "EXAMPLE";

--- a/examples/esp32-homie-example/main/main.c
+++ b/examples/esp32-homie-example/main/main.c
@@ -1,0 +1,84 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include "nvs_flash.h"
+
+#include "esp_system.h"
+#include "esp_wifi.h"
+#include "esp_event_loop.h"
+#include "freertos/event_groups.h"
+
+#include "esp_log.h"
+#include "homie.h"
+
+static const char* TAG = "EXAMPLE";
+
+static EventGroupHandle_t wifi_event_group;
+const static int CONNECTED_BIT = BIT0;
+
+static esp_err_t wifi_event_handler(void *ctx, system_event_t *event)
+{
+    switch (event->event_id) {
+        case SYSTEM_EVENT_STA_START:
+            esp_wifi_connect();
+            break;
+        case SYSTEM_EVENT_STA_GOT_IP:
+            xEventGroupSetBits(wifi_event_group, CONNECTED_BIT);
+            break;
+        case SYSTEM_EVENT_STA_DISCONNECTED:
+            esp_wifi_connect();
+            xEventGroupClearBits(wifi_event_group, CONNECTED_BIT);
+            break;
+        default:
+            break;
+    }
+    return ESP_OK;
+}
+
+static void wifi_init(void)
+{
+    tcpip_adapter_init();
+    wifi_event_group = xEventGroupCreate();
+    ESP_ERROR_CHECK(esp_event_loop_init(wifi_event_handler, NULL));
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+    ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_RAM));
+    wifi_config_t wifi_config = {
+        .sta = {
+            .ssid = CONFIG_WIFI_SSID,
+            .password = CONFIG_WIFI_PASSWORD,
+        },
+    };
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
+    ESP_LOGI(TAG, "start the WIFI SSID:[%s] password:[%s]", CONFIG_WIFI_SSID, "******");
+    ESP_ERROR_CHECK(esp_wifi_start());
+    ESP_LOGI(TAG, "Waiting for wifi");
+    xEventGroupWaitBits(wifi_event_group, CONNECTED_BIT, false, true, portMAX_DELAY);
+}
+
+void app_main()
+{
+    ESP_ERROR_CHECK(nvs_flash_init());
+
+    wifi_init();
+
+    homie_config_t homie_conf = {
+        .mqtt_uri = CONFIG_MQTT_URI,
+        .mqtt_username = CONFIG_MQTT_USERNAME,
+        .mqtt_password = CONFIG_MQTT_PASSWORD,
+        .device_name = "My Device",
+        .base_topic = "homie",
+        .firmware_name = "Example",
+        .firmware_version = "0.0.1",
+        .ota_enabled = true,
+    };
+
+    homie_init(&homie_conf);
+
+    // Keep the main task around
+    while (1) {
+        vTaskDelay(1000/portTICK_PERIOD_MS);
+    }
+}

--- a/examples/esp32-homie-example/partitions.csv
+++ b/examples/esp32-homie-example/partitions.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x190000,
+app1,     app,  ota_1,   0x200000,0x190000,
+

--- a/examples/esp32-homie-example/sdkconfig.defaults
+++ b/examples/esp32-homie-example/sdkconfig.defaults
@@ -1,11 +1,4 @@
-# Override defaults
-CONFIG_WIFI_ENABLED=y
-
-# Project configuration
-CONFIG_WIFI_SSID="myssid"
-CONFIG_WIFI_PASSWORD="mypassword"
-CONFIG_MQTT_URI="mqtt://mqtt.example.com:1883"
-
-# Partition table
+CONFIG_PARTITION_TABLE_TWO_OTA=y
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"

--- a/examples/esp32-homie-example/sdkconfig.defaults
+++ b/examples/esp32-homie-example/sdkconfig.defaults
@@ -1,0 +1,11 @@
+# Override defaults
+CONFIG_WIFI_ENABLED=y
+
+# Project configuration
+CONFIG_WIFI_SSID="myssid"
+CONFIG_WIFI_PASSWORD="mypassword"
+CONFIG_MQTT_URI="mqtt://mqtt.example.com:1883"
+
+# Partition table
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"

--- a/include/homie.h
+++ b/include/homie.h
@@ -3,7 +3,7 @@
 
 #include "mqtt_client.h"
 
-#define HOMIE_MAX_TOPIC_LEN (64)
+#define HOMIE_MAX_TOPIC_LEN (65)
 
 #define HOMIE_MAX_MQTT_URI_LEN (64)
 #define HOMIE_MAX_MQTT_USERNAME_LEN (32)

--- a/include/homie.h
+++ b/include/homie.h
@@ -1,6 +1,7 @@
 #ifndef CM_ESP32_HOMIE_H
 #define CM_ESP32_HOMIE_H
 
+#include <esp_err.h>
 #include "mqtt_client.h"
 
 #define HOMIE_MAX_TOPIC_LEN (65)
@@ -32,12 +33,12 @@ typedef struct
     void (*ota_status_handler)(int);
 } homie_config_t;
 
-void homie_init(homie_config_t *config);
+esp_err_t homie_init(homie_config_t *config);
 void homie_subscribe(const char *subtopic);
 void homie_publish(const char *subtopic, int qos, int retain, const char *payload);
 void homie_publishf(const char *subtopic, int qos, int retain, const char *format, ...);
 void homie_publish_int(const char *subtopic, int qos, int retain, const int payload);
 void homie_publish_bool(const char *subtopic, int qos, int retain, const bool payload);
-void homie_mktopic(char *topic, const char *subtopic);
+esp_err_t homie_mktopic(char *topic, const char *subtopic);
 
 #endif // CM_ESP32_HOMIE_H


### PR DESCRIPTION
This PR supports `esp-idf` master.

`snprintf(3)` usages in the code have been replaced with a common idiom. there are other possible sources of bugs, but tests should be added first. you may drop 57d1226.

* remove submodules in `esp32-homie-example` (not needed any more)
* the build matrix includes `esp-idf` versions and build methods
* check return value of `snprintf(3)`